### PR TITLE
Add unit tests for com.mm.dao and com.mm.model 

### DIFF
--- a/ZLogic/src/test/java/com/mm/dao/ZMasterDaoImplTest.java
+++ b/ZLogic/src/test/java/com/mm/dao/ZMasterDaoImplTest.java
@@ -1,0 +1,79 @@
+package com.mm.dao;
+
+import com.mm.dao.ZMasterDaoImpl;
+import com.mm.model.City;
+import com.mm.model.District;
+import com.mm.model.State;
+import com.mm.model.ZipCode;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+public class ZMasterDaoImplTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getCityInputNullNullOutputNull() throws Exception {
+
+    // Arrange
+    final ZMasterDaoImpl objectUnderTest = new ZMasterDaoImpl();
+    final Long districtID = null;
+    final Boolean status = null;
+
+    // Act
+    final List<City> actual = objectUnderTest.getCity(districtID, status);
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getDistrictInputNullNullOutputNull() throws Exception {
+
+    // Arrange
+    final ZMasterDaoImpl objectUnderTest = new ZMasterDaoImpl();
+    final Long stateID = null;
+    final Boolean status = null;
+
+    // Act
+    final List<District> actual = objectUnderTest.getDistrict(stateID, status);
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getStateOutputNull() throws Exception {
+
+    // Arrange
+    final ZMasterDaoImpl objectUnderTest = new ZMasterDaoImpl();
+
+    // Act
+    final List<State> actual = objectUnderTest.getState();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getZipCodeInputNullNullOutputNull() throws Exception {
+
+    // Arrange
+    final ZMasterDaoImpl objectUnderTest = new ZMasterDaoImpl();
+    final Long cityID = null;
+    final Boolean status = null;
+
+    // Act
+    final List<ZipCode> actual = objectUnderTest.getZipCode(cityID, status);
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+}

--- a/ZLogic/src/test/java/com/mm/dao/ZUserDaoImplTest.java
+++ b/ZLogic/src/test/java/com/mm/dao/ZUserDaoImplTest.java
@@ -1,0 +1,59 @@
+package com.mm.dao;
+
+import com.mm.dao.ZUserDaoImpl;
+import com.mm.model.VUser;
+import com.mm.model.ZUser;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+public class ZUserDaoImplTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void addVendorInputNullOutputFalse() throws Exception {
+
+    // Arrange
+    final ZUserDaoImpl objectUnderTest = new ZUserDaoImpl();
+    final VUser user = null;
+
+    // Act
+    final boolean actual = objectUnderTest.addVendor(user);
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+
+  @Test
+  public void getUserListOutputNull() throws Exception {
+
+    // Arrange
+    final ZUserDaoImpl objectUnderTest = new ZUserDaoImpl();
+
+    // Act
+    final List<ZUser> actual = objectUnderTest.getUserList();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void loginUserInputNullOutputFalse() throws Exception {
+
+    // Arrange
+    final ZUserDaoImpl objectUnderTest = new ZUserDaoImpl();
+    final ZUser user = null;
+
+    // Act
+    final boolean actual = objectUnderTest.loginUser(user);
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+}

--- a/ZLogic/src/test/java/com/mm/model/EmployeeTest.java
+++ b/ZLogic/src/test/java/com/mm/model/EmployeeTest.java
@@ -1,0 +1,81 @@
+package com.mm.model;
+
+import com.mm.model.Employee;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class EmployeeTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getEmailOutputNull() {
+
+    // Arrange
+    final Employee objectUnderTest = new Employee();
+
+    // Act
+    final String actual = objectUnderTest.getEmail();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getFirstNameOutputNull() {
+
+    // Arrange
+    final Employee objectUnderTest = new Employee();
+
+    // Act
+    final String actual = objectUnderTest.getFirstName();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getIdOutputZero() {
+
+    // Arrange
+    final Employee objectUnderTest = new Employee();
+
+    // Act
+    final long actual = objectUnderTest.getId();
+
+    // Assert result
+    Assert.assertEquals(0L, actual);
+  }
+
+
+  @Test
+  public void getLastNameOutputNull() {
+
+    // Arrange
+    final Employee objectUnderTest = new Employee();
+
+    // Act
+    final String actual = objectUnderTest.getLastName();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getPhoneOutputNull() {
+
+    // Arrange
+    final Employee objectUnderTest = new Employee();
+
+    // Act
+    final String actual = objectUnderTest.getPhone();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+}

--- a/ZLogic/src/test/java/com/mm/model/StatusTest.java
+++ b/ZLogic/src/test/java/com/mm/model/StatusTest.java
@@ -1,0 +1,39 @@
+package com.mm.model;
+
+import com.mm.model.Status;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class StatusTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getCodeOutputZero() {
+
+    // Arrange
+    final Status objectUnderTest = new Status();
+
+    // Act
+    final int actual = objectUnderTest.getCode();
+
+    // Assert result
+    Assert.assertEquals(0, actual);
+  }
+
+
+  @Test
+  public void getMessageOutputNull() {
+
+    // Arrange
+    final Status objectUnderTest = new Status();
+
+    // Act
+    final String actual = objectUnderTest.getMessage();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+}

--- a/ZLogic/src/test/java/com/mm/model/VUserTest.java
+++ b/ZLogic/src/test/java/com/mm/model/VUserTest.java
@@ -1,0 +1,269 @@
+package com.mm.model;
+
+import com.mm.model.VUser;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class VUserTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getAadharNoOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getAadharNo();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getAddressOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getAddress();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getAgeOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getAge();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getCityOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getCity();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getDistrictOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getDistrict();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getDobOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getDob();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getEmailOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getEmail();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getFirstNameOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getFirstName();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getIdOutputZero() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final long actual = objectUnderTest.getId();
+
+    // Assert result
+    Assert.assertEquals(0L, actual);
+  }
+
+
+  @Test
+  public void getImagePathOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getImagePath();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getLastNameOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getLastName();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getPhoneOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getPhone();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getStateOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getState();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getStatusOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getStatus();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getVendorIDPathOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getVendorIDPath();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getZipCodeOutputNull() {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+
+    // Act
+    final String actual = objectUnderTest.getZipCode();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void toStringOutputNotNull() throws InvocationTargetException {
+
+    // Arrange
+    final VUser objectUnderTest = new VUser();
+    objectUnderTest.setPhone("");
+    objectUnderTest.setId(-9L);
+    objectUnderTest.setDob("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    objectUnderTest.setStatus("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+    objectUnderTest.setEmail(
+        "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"");
+    objectUnderTest.setFirstName("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    objectUnderTest.setAddress("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    objectUnderTest.setLastName("");
+    objectUnderTest.setAge("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    objectUnderTest.setAadharNo("");
+    objectUnderTest.setVendorIDPath("");
+    objectUnderTest.setDistrict("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+    objectUnderTest.setImagePath("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    objectUnderTest.setState("");
+    objectUnderTest.setCity("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    objectUnderTest.setZipCode("BBBBBBBBBBBBBBBBBBBBBBB");
+
+    // Act
+    final String actual = objectUnderTest.toString();
+
+    // Assert result
+    Assert.assertEquals(
+        "VUser [id=-9, firstName=!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!, lastName=, email=\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\", phone=, aadharNo=, state=, district=@@@@@@@@@@@@@@@@@@@@@@@@@@@@@, city=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, zipCode=BBBBBBBBBBBBBBBBBBBBBBB, address=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, age=!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!, status=BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB, imagePath=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, vendorIDPath=, dob=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA]",
+        actual);
+  }
+}

--- a/ZLogic/src/test/java/com/mm/model/ZUserTest.java
+++ b/ZLogic/src/test/java/com/mm/model/ZUserTest.java
@@ -1,0 +1,178 @@
+package com.mm.model;
+
+import com.mm.model.ZUser;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class ZUserTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void getCodeOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final String actual = objectUnderTest.getCode();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getEmailOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final String actual = objectUnderTest.getEmail();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getFirstNameOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final String actual = objectUnderTest.getFirstName();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getIdOutputZero() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final long actual = objectUnderTest.getId();
+
+    // Assert result
+    Assert.assertEquals(0L, actual);
+  }
+
+
+  @Test
+  public void getIsActiveOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final Boolean actual = objectUnderTest.getIsActive();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void getIsAdminOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final Boolean actual = objectUnderTest.getIsAdmin();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getLastNameOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final String actual = objectUnderTest.getLastName();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getPasswordOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final String actual = objectUnderTest.getPassword();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getPhoneOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final String actual = objectUnderTest.getPhone();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void getUsernameOutputNull() {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+
+    // Act
+    final String actual = objectUnderTest.getUsername();
+
+    // Assert result
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void toStringOutputNotNull() throws InvocationTargetException {
+
+    // Arrange
+    final ZUser objectUnderTest = new ZUser();
+    objectUnderTest.setEmail("");
+    objectUnderTest.setPassword("HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH");
+    objectUnderTest.setIsActive(true);
+    objectUnderTest.setLastName("AAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    objectUnderTest.setPhone("DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD");
+    objectUnderTest.setId(4L);
+    objectUnderTest.setCode("");
+    objectUnderTest.setIsAdmin(true);
+    objectUnderTest.setFirstName("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    objectUnderTest.setUsername("");
+
+    // Act
+    final String actual = objectUnderTest.toString();
+
+    // Assert result
+    Assert.assertEquals(
+        "ZUser [id=4, username=, code=, firstName=!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!, lastName=AAAAAAAAAAAAAAAAAAAAAAAAAAAA, email=, phone=DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD, password=HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH, isActive=true, isAdmin=true]",
+        actual);
+  }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.mm.dao` and `com.mm.model` have not been tested.

These tests have been created by [Diffblue Cover](https://www.diffblue.com/opensource) and filtered for their quality via our test ranking system. We like to hear your feedback on the quality of these tests and whether you would consider them as mergeable. 

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.